### PR TITLE
SJRK-64: add retrying behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Can currently do the following:
 
 ## Notes
 
-Uses the official CouchDB Node library, [Nano](https://github.com/apache/couchdb-nano).
+* Uses the official CouchDB Node library, [Nano](https://github.com/apache/couchdb-nano).
+
+* Includes a behaviour-based grade (`fluid.couchConfig.retryingBehaviour`) to implement retrying functionality, which is useful when running initial configuration in distributed environments such as containerization
 
 ## Usage
 

--- a/examples/js/couchConfigBasic.js
+++ b/examples/js/couchConfigBasic.js
@@ -77,7 +77,6 @@ fluid.couchConfig.example.tagCountReduceFunction = function (keys, values, rered
 
 // eslint-disable-next-line no-unused-vars
 fluid.couchConfig.example.validateFunction = function (newDoc, oldDoc, userCtx, secObj) {
-
     if (!newDoc.type) {
         throw ({forbidden: "doc.type is required"});
     }

--- a/examples/js/couchConfigBasic.js
+++ b/examples/js/couchConfigBasic.js
@@ -64,7 +64,7 @@ fluid.couchConfig.example.docIdsWithTitlesMapFunction = function (doc) {
     emit(doc._id, doc.title);
 };
 
-// http://localhost:5984/test/_design/views/_view/tagCount?group=true
+// http://localhost:5984/basic-fluid-couch-config-db/_design/exampleDesignDocument/_view/tagCount?group=true
 fluid.couchConfig.example.tagCountMapFunction = function (doc) {
     if (doc.tags.length > 0) {
         for (var idx in doc.tags) {

--- a/examples/js/couchConfigBasic.js
+++ b/examples/js/couchConfigBasic.js
@@ -22,8 +22,8 @@ fluid.defaults("fluid.couchConfig.example", {
     },
     listeners: {
         onCreate: "{that}.configureCouch",
-        onSuccess: "console.log(SUCCESS)",
-        onError: "console.log({arguments}.0.message)"
+        onSuccess: "fluid.log(SUCCESS)",
+        onError: "fluid.log({arguments}.0.message)"
     },
     dbDocuments: {
         test1: {

--- a/examples/js/couchConfigBasic.js
+++ b/examples/js/couchConfigBasic.js
@@ -18,12 +18,12 @@ require("../../src/couchConfig");
 fluid.defaults("fluid.couchConfig.example", {
     gradeNames: ["fluid.couchConfig.pipeline"],
     couchOptions: {
-        dbName: "test-fluid-couch-config-db"
+        dbName: "basic-fluid-couch-config-db"
     },
     listeners: {
         onCreate: "{that}.configureCouch",
         onSuccess: "console.log(SUCCESS)",
-        onError: "console.log({arguments}.0)"
+        onError: "console.log({arguments}.0.message)"
     },
     dbDocuments: {
         test1: {

--- a/examples/js/couchConfigBasic.js
+++ b/examples/js/couchConfigBasic.js
@@ -44,16 +44,19 @@ fluid.defaults("fluid.couchConfig.example", {
         }
     },
     dbDesignDocuments: {
-        views: {
-            docIdsWithTitles: {
-                map: "fluid.couchConfig.example.docIdsWithTitlesMapFunction"
-            },
-            tagCount: {
-                map: "fluid.couchConfig.example.tagCountMapFunction",
-                reduce: "fluid.couchConfig.example.tagCountReduceFunction"
+        exampleDesignDocument: {
+            views: {
+                docIdsWithTitles: {
+                    map: "fluid.couchConfig.example.docIdsWithTitlesMapFunction"
+                },
+                tagCount: {
+                    map: "fluid.couchConfig.example.tagCountMapFunction",
+                    reduce: "fluid.couchConfig.example.tagCountReduceFunction"
+                }
             },
             validate_doc_update: "fluid.couchConfig.example.validateFunction"
         }
+
     }
 });
 

--- a/examples/js/couchConfigBasic.js
+++ b/examples/js/couchConfigBasic.js
@@ -16,40 +16,44 @@ var fluid = require("infusion");
 require("../../src/couchConfig");
 
 fluid.defaults("fluid.couchConfig.example", {
-    gradeNames: ["fluid.couchConfig.auto"],
-    dbConfig: {
-        dbName: "test",
-        designDocName: "views"
+    gradeNames: ["fluid.couchConfig.pipeline"],
+    couchOptions: {
+        dbName: "test-fluid-couch-config-db"
+    },
+    listeners: {
+        onCreate: "{that}.configureCouch",
+        onSuccess: "console.log(SUCCESS)",
+        onError: "console.log({arguments}.0)"
     },
     dbDocuments: {
-        "test1": {
-            "title": "Hello, World!",
-            "tags": ["hello", "world", "test"],
-            "type": "post"
+        test1: {
+            title: "Hello, World!",
+            tags: ["hello", "world", "test"],
+            type: "post"
         },
-        "test2": {
-            "title": "Goodbye, World!",
-            "tags": ["goodbye", "world", "test"],
-            "type": "post"
+        test2: {
+            title: "Goodbye, World!",
+            tags: ["goodbye", "world", "test"],
+            type: "post"
         },
         // This document will fail to be updated/inserted due to the
         // validation function
-        "test3": {
-            "title": "I don't have a 'type' field. I'm going to fail validation.",
-            "tags": ["invalid", "test"]
+        test3: {
+            title: "I don't have a 'type' field. I'm going to fail validation.",
+            tags: ["invalid", "test"]
         }
     },
-    dbViews: {
-        "docIdsWithTitles": {
-            "map": "fluid.couchConfig.example.docIdsWithTitlesMapFunction"
-        },
-        "tagCount": {
-            "map": "fluid.couchConfig.example.tagCountMapFunction",
-            "reduce": "fluid.couchConfig.example.tagCountReduceFunction"
+    dbDesignDocuments: {
+        views: {
+            docIdsWithTitles: {
+                map: "fluid.couchConfig.example.docIdsWithTitlesMapFunction"
+            },
+            tagCount: {
+                map: "fluid.couchConfig.example.tagCountMapFunction",
+                reduce: "fluid.couchConfig.example.tagCountReduceFunction"
+            },
+            validate_doc_update: "fluid.couchConfig.example.validateFunction"
         }
-    },
-    dbValidate: {
-        validateFunction: "fluid.couchConfig.example.validateFunction"
     }
 });
 

--- a/index.js
+++ b/index.js
@@ -14,5 +14,5 @@ var fluid = require("infusion");
 
 require("./src/couchConfig");
 
-// Register our content so that it can be referenced in other packages using `fluid.module.resolvePath("%gpii-binder/path/to/content")`
-fluid.module.register("couch-config", __dirname, require);
+// Register our content so that it can be referenced in other packages using `fluid.module.resolvePath("%fluid-couch-config/path/to/content")`
+fluid.module.register("fluid-couch-config", __dirname, require);

--- a/src/couchConfig.js
+++ b/src/couchConfig.js
@@ -96,7 +96,7 @@ fluid.defaults("fluid.couchConfig.createDbIfNotExist", {
     invokers: {
         doAction: {
             funcName: "fluid.couchConfig.createDbIfNotExist.doAction",
-            args: [{}, "{couchConfig}.options.couchOptions"]
+            args: [{}, "{couchConfig}.options"]
         }
     }
 });
@@ -152,27 +152,31 @@ fluid.defaults("fluid.couchConfig.updateDesignDocument", {
     invokers: {
         doAction: {
             funcName: "fluid.couchConfig.updateDesignDocument.doAction",
-            args: [{}, "{couchConfig}.options.couchOptions"]
+            args: [{}, "{couchConfig}.options"]
         }
     }
 });
 
-fluid.couchConfig.designDocument.renderFunctionString = function (func) {
-    // Direct function references
-    if (typeof func === "function") {
-        return func.toString();
-    }
-    // Resolve funcNames using fluid.getGlobalValue
-    if (typeof func === "string") {
-        var namedFunc = fluid.getGlobalValue(func);
-        return namedFunc.toString();
+fluid.couchConfig.updateDesignDocument.renderFunctionString = function (func) {
+    if (func) {
+        // Direct function references
+        if (typeof func === "function") {
+            return func.toString();
+        }
+        // Resolve funcNames using fluid.getGlobalValue
+        if (typeof func === "string") {
+            var namedFunc = fluid.getGlobalValue(func);
+            return namedFunc.toString();
+        }
+    } else {
+        return func;
     }
 };
 
-fluid.couchConfig.designDocument.renderViewFunctions = function (viewsCollection) {
+fluid.couchConfig.updateDesignDocument.renderViewFunctions = function (viewsCollection) {
     var transformedViews = fluid.transform(viewsCollection, function (desiredView, viewKey) {
         // The special-case validate_doc_update function
-        if (viewKey === "validate_doc_update") {
+        if (viewKey && viewKey === "validate_doc_update") {
             return fluid.couchConfig.designDocument.renderFunctionString(desiredView);
         } else {
             return fluid.transform(desiredView, function (viewFunc, funcKey) {
@@ -286,7 +290,7 @@ fluid.defaults("fluid.couchConfig.updateDocuments", {
     invokers: {
         doAction: {
             funcName: "fluid.couchConfig.updateDocuments.doAction",
-            args: [{}, "{couchConfig}.options.couchOptions"]
+            args: [{}, "{couchConfig}.options"]
         }
     }
 });

--- a/src/couchConfig.js
+++ b/src/couchConfig.js
@@ -246,17 +246,7 @@ fluid.couchConfig.action.updateDocuments = function (payload, options, docs) {
 
     var promises = [];
     fluid.each(docs, function (doc, id) {
-        console.log(
-            fluid.stringTemplate(
-                "Updating document at %couchUrl/%dbName/%id with defined views",
-                {
-                    couchUrl: options.couchOptions.couchUrl,
-                    dbName: options.couchOptions.dbName,
-                    id: id
-                }
-            )
-        );
-
+        console.log(fluid.stringTemplate("Updating document at %dbName/%id", { dbName: options.couchOptions.dbName, id: id }));
         promises.push(fluid.couchConfig.action.updateSingleDocument(targetDb, doc, id));
     });
 

--- a/src/couchConfig.js
+++ b/src/couchConfig.js
@@ -371,8 +371,8 @@ fluid.defaults("fluid.couchConfig.pipeline", {
     }
 });
 
-fluid.defaults("fluid.couchConfig.pipeline.retrying", {
-    gradeNames: ["fluid.retrying"],
+fluid.defaults("fluid.couchConfig.pipeline.retryingBehaviour", {
+    gradeNames: ["fluid.couchConfig.retryingBehaviour"],
     events: {
         "onAttemptFailure": "{couchConfig}.events.onError"
     },
@@ -383,11 +383,11 @@ fluid.defaults("fluid.couchConfig.pipeline.retrying", {
     }
 });
 
-fluid.defaults("fluid.couchConfig.pipeline.retryable", {
+fluid.defaults("fluid.couchConfig.pipeline.retrying", {
     gradeNames: ["fluid.couchConfig.pipeline"],
     components: {
-        retrying: {
-            type: "fluid.couchConfig.pipeline.retrying",
+        retryingBehaviour: {
+            type: "fluid.couchConfig.pipeline.retryingBehaviour",
         }
     }
 });

--- a/src/couchConfig.js
+++ b/src/couchConfig.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 OCAD University
+Copyright 2017-2018 OCAD University
 Licensed under the Educational Community License (ECL), Version 2.0 or the New
 BSD license. You may not use this file except in compliance with one these
 Licenses.
@@ -10,49 +10,9 @@ https://raw.githubusercontent.com/fluid-project/fluid-couch-config/master/LICENS
 "use strict";
 
 var fluid = require("infusion");
-fluid.setLogging(true);
+require("./retrying");
 
 var isEqual = require("underscore").isEqual;
-
-fluid.defaults("fluid.retrying", {
-    gradeNames: ["fluid.modelComponent"],
-    retryOptions: {
-        maxRetries: 3,
-        retryDelay: 10
-    },
-    model: {
-        currentRetries: 0
-    },
-    events: {
-        "onError": "{couchConfig}.events.onError"
-    },
-    listeners: {
-        "onError.handleRetry": "{that}.handleRetry"
-    },
-    invokers: {
-        handleRetry: {
-            funcName: "fluid.retrying.handleRetry",
-            args: ["{that}", "{couchConfig}.configureCouch"]
-        }
-    }
-});
-
-fluid.retrying.handleRetry = function (retrying, retryingFunction) {
-    var maxRetries = retrying.options.retryOptions.maxRetries,
-        retryDelay = retrying.options.retryOptions.retryDelay,
-        currentRetries = retrying.model.currentRetries;
-
-        if (currentRetries < maxRetries) {
-            retrying.applier.change("currentRetries", currentRetries + 1);
-            fluid.log("Retry " + retrying.model.currentRetries + " of " + maxRetries + "; retrying after " + retryDelay + " seconds");
-            setTimeout(function () {
-                retryingFunction();
-            }, retryDelay * 1000);
-
-        } else {
-            fluid.log("Max retries exceeded");
-        }
-};
 
 fluid.defaults("fluid.couchConfig", {
     gradeNames: "fluid.component",
@@ -411,11 +371,23 @@ fluid.defaults("fluid.couchConfig.pipeline", {
     }
 });
 
+fluid.defaults("fluid.couchConfig.pipeline.retrying", {
+    gradeNames: ["fluid.retrying"],
+    events: {
+        "onError": "{couchConfig}.events.onError"
+    },
+    invokers: {
+        retryFunction: {
+            func: "{couchConfig}.configureCouch"
+        }
+    }
+});
+
 fluid.defaults("fluid.couchConfig.pipeline.retryable", {
     gradeNames: ["fluid.couchConfig.pipeline"],
     components: {
         retrying: {
-            type: "fluid.retrying"
+            type: "fluid.couchConfig.pipeline.retrying",
         }
     }
 });

--- a/src/couchConfig.js
+++ b/src/couchConfig.js
@@ -374,7 +374,7 @@ fluid.defaults("fluid.couchConfig.pipeline", {
 fluid.defaults("fluid.couchConfig.pipeline.retrying", {
     gradeNames: ["fluid.retrying"],
     events: {
-        "onError": "{couchConfig}.events.onError"
+        "onAttemptFailure": "{couchConfig}.events.onError"
     },
     invokers: {
         retryFunction: {

--- a/src/couchConfig.js
+++ b/src/couchConfig.js
@@ -189,7 +189,7 @@ fluid.couchConfig.updateDesignDocument.renderViewFunctions = function (viewsColl
 fluid.couchConfig.action.writeToDb = function (targetDb, doc, id) {
     var togo = fluid.promise();
 
-    targetDb.insert(doc, id, function (err, body) {
+    targetDb.insert(doc, id, function (err) {
         if (!err) {
             console.log("Document " + id + " inserted successfully");
             togo.resolve();
@@ -197,7 +197,7 @@ fluid.couchConfig.action.writeToDb = function (targetDb, doc, id) {
             console.log("Error in inserting document " + id);
             togo.reject({
                 isError: true,
-                message: err + " " + body,
+                message: err + ", document ID: " + id,
                 statusCode: err.statusCode
             });
         }

--- a/src/couchConfig.js
+++ b/src/couchConfig.js
@@ -28,11 +28,11 @@ fluid.defaults("fluid.couchConfig", {
     dbDesignDocuments: {
         // An object whose keys are the names of design documents to be
         // created in the database. Each design document can have a
-        // collection of zero or more views, where the keys are the names
-        // of each view. Each view would in turn have the keys "map" and
-        // "reduce", which are function references or function names for
-        // functions accessible by couchConfig. These functions, internally,
-        // can only refer to other functions known to CouchDB.
+        // collection of zero or more views under the key 'views', where th
+        // keys are the name of each view. Each view would in turn have the
+        // keys "map" and "reduce", which are function references or function
+        // names for functions accessible by couchConfig. These functions,
+        // internally, can only refer to other functions known to CouchDB.
         // http://guide.couchdb.org/editions/1/en/views.html
         // TODO: verify that this last claim is accurate
 
@@ -46,13 +46,15 @@ fluid.defaults("fluid.couchConfig", {
 
         // for example:
         // designDocumentName: {
-        //     someViewFunction: {
-        //         map: "reference.to.a.function",
-        //         reduce: "reference.to.another.function"
-        //     },
-        //     anotherViewFunction: {
-        //         map: "reference.to.yet.another.function",
-        //         reduce: "reference.to.still.another.function"
+        //     views: {
+        //         someViewFunction: {
+        //             map: "reference.to.a.function",
+        //             reduce: "reference.to.another.function"
+        //         },
+        //         anotherViewFunction: {
+        //             map: "reference.to.yet.another.function",
+        //             reduce: "reference.to.still.another.function"
+        //         }
         //     },
         //     validate_doc_update: "a.validation.function"
         // }

--- a/src/couchConfig.js
+++ b/src/couchConfig.js
@@ -19,43 +19,43 @@ fluid.defaults("fluid.couchConfig", {
     couchOptions: {
         couchUrl: "http://localhost:5984",
         dbName: null, // To be provided
-        dbDocuments: {
-            // An object whose keys are the IDs of documents to
-            // be created in the database, and the values are the documents
-            // themselves.
-        },
-        dbDesignDocuments: {
-            // An object whose keys are the names of design documents to be
-            // created in the database. Each design document can have a
-            // collection of zero or more views, where the keys are the names
-            // of each view. Each view would in turn have the keys "map" and
-            // "reduce", which are function references or function names for
-            // functions accessible by couchConfig. These functions, internally,
-            // can only refer to other functions known to CouchDB.
-            // http://guide.couchdb.org/editions/1/en/views.html
-            // TODO: verify that this last claim is accurate
+    },
+    dbDocuments: {
+        // An object whose keys are the IDs of documents to
+        // be created in the database, and the values are the documents
+        // themselves.
+    },
+    dbDesignDocuments: {
+        // An object whose keys are the names of design documents to be
+        // created in the database. Each design document can have a
+        // collection of zero or more views, where the keys are the names
+        // of each view. Each view would in turn have the keys "map" and
+        // "reduce", which are function references or function names for
+        // functions accessible by couchConfig. These functions, internally,
+        // can only refer to other functions known to CouchDB.
+        // http://guide.couchdb.org/editions/1/en/views.html
+        // TODO: verify that this last claim is accurate
 
-            // Additionally, "reduce" may specify by name one of the three
-            // built-in reduce functions: "_sum", "_count", or "_stats"
-            // https://wiki.apache.org/couchdb/Built-In_Reduce_Functions
+        // Additionally, "reduce" may specify by name one of the three
+        // built-in reduce functions: "_sum", "_count", or "_stats"
+        // https://wiki.apache.org/couchdb/Built-In_Reduce_Functions
 
-            // Each design document may also have up to one validate_doc_update
-            // function, and must conform to this specification:
-            // http://guide.couchdb.org/editions/1/en/validation.html
+        // Each design document may also have up to one validate_doc_update
+        // function, and must conform to this specification:
+        // http://guide.couchdb.org/editions/1/en/validation.html
 
-            // for example:
-            // designDocumentName: {
-            //     someViewFunction: {
-            //         map: "reference.to.a.function",
-            //         reduce: "reference.to.another.function"
-            //     },
-            //     anotherViewFunction: {
-            //         map: "reference.to.yet.another.function",
-            //         reduce: "reference.to.still.another.function"
-            //     },
-            //     validate_doc_update: "a.validation.function"
-            // }
-        }
+        // for example:
+        // designDocumentName: {
+        //     someViewFunction: {
+        //         map: "reference.to.a.function",
+        //         reduce: "reference.to.another.function"
+        //     },
+        //     anotherViewFunction: {
+        //         map: "reference.to.yet.another.function",
+        //         reduce: "reference.to.still.another.function"
+        //     },
+        //     validate_doc_update: "a.validation.function"
+        // }
     },
     invokers: {
         configureCouch: {

--- a/src/couchConfig.js
+++ b/src/couchConfig.js
@@ -206,23 +206,24 @@ fluid.couchConfig.updateDesignDocument.renderFunctionString = function (func) {
     }
 };
 
-fluid.couchConfig.updateDesignDocument.renderViewFunctions = function (viewsCollection) {
-    var transformedViews = fluid.transform(viewsCollection, function (desiredView, viewKey) {
+fluid.couchConfig.updateDesignDocument.renderViewFunctions = function (designDocument) {
+    var transformedDesignDocument = fluid.transform(designDocument, function (obj, key) {
         // The special-case validate_doc_update function
-        if (viewKey && viewKey === "validate_doc_update") {
-            return fluid.couchConfig.updateDesignDocument.renderFunctionString(desiredView);
-        } else {
-            return fluid.transform(desiredView, function (viewFunc, funcKey) {
-                // The internal CouchDB reduce functions
-                if (funcKey === "reduce" && (viewFunc === "_count" || viewFunc === "_sum" || viewFunc === "_stats")) {
-                    return viewFunc;
-                }
-
-                return fluid.couchConfig.updateDesignDocument.renderFunctionString(viewFunc);
+        if (key && key === "validate_doc_update") {
+            return fluid.couchConfig.updateDesignDocument.renderFunctionString(obj);
+        } else if (key && key === "views"){
+            return fluid.transform(obj, function (desiredView) {
+                return fluid.transform(desiredView, function (viewFunc, funcKey) {
+                    // The internal CouchDB reduce functions
+                    if (funcKey === "reduce" && (viewFunc === "_count" || viewFunc === "_sum" || viewFunc === "_stats")) {
+                        return viewFunc;
+                    }
+                    return fluid.couchConfig.updateDesignDocument.renderFunctionString(viewFunc);
+                });
             });
         }
     });
-    return transformedViews;
+    return transformedDesignDocument;
 };
 
 fluid.couchConfig.action.writeToDb = function (targetDb, doc, id) {

--- a/src/retrying.js
+++ b/src/retrying.js
@@ -12,8 +12,10 @@ https://raw.githubusercontent.com/fluid-project/fluid-couch-config/master/LICENS
 var fluid = require("infusion");
 
 // Can be used as a subcomponent to implement
-// retrying behaviour
-fluid.defaults("fluid.retrying", {
+// retrying behaviour for an action that can
+// potentially fail, such as in a distributed
+// application set-up
+fluid.defaults("fluid.couchConfig.retryingBehaviour", {
     gradeNames: ["fluid.modelComponent"],
     retryOptions: {
         maxRetries: 3,
@@ -33,7 +35,7 @@ fluid.defaults("fluid.retrying", {
     },
     invokers: {
         handleRetry: {
-            funcName: "fluid.retrying.handleRetry",
+            funcName: "fluid.couchConfig.retryingBehaviour.handleRetry",
             args: ["{that}", "{that}.retryFunction"]
         },
         retryFunction: {
@@ -42,7 +44,7 @@ fluid.defaults("fluid.retrying", {
     }
 });
 
-fluid.retrying.handleRetry = function (retrying, retryingFunction) {
+fluid.couchConfig.retryingBehaviour.handleRetry = function (retrying, retryingFunction) {
     var maxRetries = retrying.options.retryOptions.maxRetries,
         retryDelay = retrying.options.retryOptions.retryDelay,
         currentRetries = retrying.model.currentRetries;
@@ -54,7 +56,7 @@ fluid.retrying.handleRetry = function (retrying, retryingFunction) {
                 retryingFunction();
             }, retryDelay * 1000);
 
-        } else {            
+        } else {
             fluid.log("Max retries exceeded");
         }
 };

--- a/src/retrying.js
+++ b/src/retrying.js
@@ -1,0 +1,61 @@
+/*
+Copyright 2017-2018 OCAD University
+Licensed under the Educational Community License (ECL), Version 2.0 or the New
+BSD license. You may not use this file except in compliance with one these
+Licenses.
+You may obtain a copy of the ECL 2.0 License and BSD License at
+https://raw.githubusercontent.com/fluid-project/fluid-couch-config/master/LICENSE.txt
+*/
+
+"use strict";
+
+var fluid = require("infusion");
+
+// Can be used as a subcomponent to implement
+// retrying behaviour
+fluid.defaults("fluid.retrying", {
+    gradeNames: ["fluid.modelComponent"],
+    retryOptions: {
+        maxRetries: 3,
+        retryDelay: 10
+    },
+    model: {
+        currentRetries: 0
+    },
+    // In an implementation, this should be
+    // bound or fired by an appropriate
+    // error event in the function etc
+    // that we wish to retry
+    events: {
+        "onError": null
+    },
+    listeners: {
+        "onError.handleRetry": "{that}.handleRetry"
+    },
+    invokers: {
+        handleRetry: {
+            funcName: "fluid.retrying.handleRetry",
+            args: ["{that}", "{that}.retryFunction"]
+        },
+        retryFunction: {
+            funcName: "fluid.notImplemented"
+        }
+    }
+});
+
+fluid.retrying.handleRetry = function (retrying, retryingFunction) {
+    var maxRetries = retrying.options.retryOptions.maxRetries,
+        retryDelay = retrying.options.retryOptions.retryDelay,
+        currentRetries = retrying.model.currentRetries;
+
+        if (currentRetries < maxRetries) {
+            retrying.applier.change("currentRetries", currentRetries + 1);
+            fluid.log("Retry " + retrying.model.currentRetries + " of " + maxRetries + "; retrying after " + retryDelay + " seconds");
+            setTimeout(function () {
+                retryingFunction();
+            }, retryDelay * 1000);
+
+        } else {
+            fluid.log("Max retries exceeded");
+        }
+};

--- a/src/retrying.js
+++ b/src/retrying.js
@@ -22,15 +22,14 @@ fluid.defaults("fluid.retrying", {
     model: {
         currentRetries: 0
     },
-    // In an implementation, this should be
-    // bound or fired by an appropriate
-    // error event in the function etc
-    // that we wish to retry
     events: {
-        "onError": null
+        // In an implementation, this should be
+        // fired to indicate a failed attempted
+        // action
+        "onAttemptFailure": null
     },
     listeners: {
-        "onError.handleRetry": "{that}.handleRetry"
+        "onAttemptFailure.handleRetry": "{that}.handleRetry"
     },
     invokers: {
         handleRetry: {
@@ -55,7 +54,7 @@ fluid.retrying.handleRetry = function (retrying, retryingFunction) {
                 retryingFunction();
             }, retryDelay * 1000);
 
-        } else {
+        } else {            
             fluid.log("Max retries exceeded");
         }
 };

--- a/tests/js/couchConfigTests.js
+++ b/tests/js/couchConfigTests.js
@@ -57,13 +57,15 @@ fluid.defaults("fluid.tests.couchConfig.testCouchConfig", {
     },
     dbDesignDocuments: {
         testViews: {
-            test: {
-                map: "fluid.tests.couchConfig.testMapFunction",
-                reduce: "fluid.tests.couchConfig.testReduceFunction"
-            },
-            test2: {
-                map: function (doc) {
-                    emit(doc, null);
+            views: {
+                test: {
+                    map: "fluid.tests.couchConfig.testMapFunction",
+                    reduce: "fluid.tests.couchConfig.testReduceFunction"
+                },
+                test2: {
+                    map: function (doc) {
+                        emit(doc, null);
+                    }
                 }
             },
             validate_doc_update: "fluid.tests.couchConfig.testValidateFunction"
@@ -335,12 +337,14 @@ var preExistingTestDoc = {
 };
 
 var preExistingTestDesignDoc = {
-    test: {
-        map: "function (doc) {if (doc.key) {emit(doc.key, null);}}",
-        reduce: "function (keys, values, rereduce) {return sum(values);}"
-    },
-    test2: {
-        map: "function (differentDoc) {emit(differentDoc, null);}"
+    views: {
+        test: {
+            map: "function (doc) {if (doc.key) {emit(doc.key, null);}}",
+            reduce: "function (keys, values, rereduce) {return sum(values);}"
+        },
+        test2: {
+            map: "function (differentDoc) {emit(differentDoc, null);}"
+        }
     },
     validate_doc_update: "function (newDoc, oldDoc, userCtx) { throw ({forbidden: \"It's not a test document\"});}"
 };
@@ -411,11 +415,11 @@ fluid.tests.couchConfig.verifyDbViewEquals = function (dbName, couchUrl, expecte
     var nano = require("nano")(couchUrl);
     var db = nano.use(dbName);
 
-    db.get("_design/testViews", function (err, actualDesignDoc) {
+    db.get("_design/testViews", function (err, actualDesignDoc) {        
         if (!err) {
-            jqUnit.assertTrue("The actual view map function is is the same as expected", fluid.tests.couchConfig.functionsAreIdentical(expectedView.testViews.test.map, actualDesignDoc.test.map));
-            jqUnit.assertTrue("The actual view reduce function is is the same as expected", fluid.tests.couchConfig.functionsAreIdentical(expectedView.testViews.test.reduce, actualDesignDoc.test.reduce));
-            jqUnit.assertTrue("The actual view inline-specified function is is the same as expected", fluid.tests.couchConfig.functionsAreIdentical(expectedView.testViews.test2.map, actualDesignDoc.test2.map));
+            jqUnit.assertTrue("The actual view map function is is the same as expected", fluid.tests.couchConfig.functionsAreIdentical(expectedView.testViews.views.test.map, actualDesignDoc.views.test.map));
+            jqUnit.assertTrue("The actual view reduce function is is the same as expected", fluid.tests.couchConfig.functionsAreIdentical(expectedView.testViews.views.test.reduce, actualDesignDoc.views.test.reduce));
+            jqUnit.assertTrue("The actual view inline-specified function is is the same as expected", fluid.tests.couchConfig.functionsAreIdentical(expectedView.testViews.views.test2.map, actualDesignDoc.views.test2.map));
             jqUnit.assertTrue("The actual validate_doc_update function is is the same as expected", fluid.tests.couchConfig.functionsAreIdentical(expectedView.testViews.validate_doc_update, actualDesignDoc.validate_doc_update));
         }
 
@@ -429,9 +433,9 @@ fluid.tests.couchConfig.verifyDbViewNotEquals = function (dbName, couchUrl, unex
 
     db.get("_design/testViews", function (err, actualDesignDoc) {
         if (!err) {
-            jqUnit.assertFalse("The actual view map function is different from unexpected", fluid.tests.couchConfig.functionsAreIdentical(unexpectedView.testViews.test.map, actualDesignDoc.test.map));
-            jqUnit.assertFalse("The actual view reduce function is different from unexpected", fluid.tests.couchConfig.functionsAreIdentical(unexpectedView.testViews.test.reduce, actualDesignDoc.test.reduce));
-            jqUnit.assertFalse("The actual view inline-specified function is different from unexpected", fluid.tests.couchConfig.functionsAreIdentical(unexpectedView.testViews.test2.map, actualDesignDoc.test2.map));
+            jqUnit.assertFalse("The actual view map function is different from unexpected", fluid.tests.couchConfig.functionsAreIdentical(unexpectedView.testViews.views.test.map, actualDesignDoc.views.test.map));
+            jqUnit.assertFalse("The actual view reduce function is different from unexpected", fluid.tests.couchConfig.functionsAreIdentical(unexpectedView.testViews.views.test.reduce, actualDesignDoc.views.test.reduce));
+            jqUnit.assertFalse("The actual view inline-specified function is different from unexpected", fluid.tests.couchConfig.functionsAreIdentical(unexpectedView.testViews.views.test2.map, actualDesignDoc.views.test2.map));
             jqUnit.assertFalse("The actual validate_doc_update function is different from unexpected", fluid.tests.couchConfig.functionsAreIdentical(unexpectedView.testViews.validate_doc_update, actualDesignDoc.validate_doc_update));
         }
 

--- a/tests/js/couchConfigTests.js
+++ b/tests/js/couchConfigTests.js
@@ -22,8 +22,6 @@ var jqUnit = require("node-jqunit");
 
 require("../../src/couchConfig");
 
-"use strict";
-
 fluid.defaults("fluid.tests.couchConfig.testCouchConfig", {
     gradeNames: ["fluid.couchConfig.db", "fluid.couchConfig.documents", "fluid.couchConfig.designDocument"],
     dbConfig: {

--- a/tests/js/couchConfigTests.js
+++ b/tests/js/couchConfigTests.js
@@ -75,9 +75,15 @@ fluid.defaults("fluid.tests.couchConfig.testCouchConfig", {
 
 fluid.defaults("fluid.tests.couchConfig.testCouchConfigRetryable", {
     gradeNames: ["fluid.couchConfig.pipeline.retryable", "fluid.tests.couchConfig.testCouchConfig"],
-    retryOptions: {
-        maxRetries: 3,
-        retryDelay: 4
+    components: {
+        retrying: {
+            options: {
+                retryOptions: {
+                    maxRetries: 3,
+                    retryDelay: 4
+                }
+            }
+        }
     }
 });
 
@@ -533,6 +539,8 @@ fluid.defaults("fluid.tests.couchConfig.retryableCouchConfigTest", {
             type: "fluid.tests.couchConfig.retryableCouchConfigTester"
         }
     },
+    // We call constructFixtures later in the test for retryable
+    // behaviour, so we have to null it out here
     listeners: {
         "onCreate.constructFixtures": null
     }

--- a/tests/js/couchConfigTests.js
+++ b/tests/js/couchConfigTests.js
@@ -601,7 +601,4 @@ fluid.defaults("fluid.tests.couchConfig.retryableCouchConfigFailureTest", {
     }
 });
 
-// TODO: restore this
-// fluid.test.runTests(["fluid.tests.couchConfig.couchConfigTest"]);
-
-fluid.test.runTests(["fluid.tests.couchConfig.retryableCouchConfigSuccessTest", "fluid.tests.couchConfig.retryableCouchConfigFailureTest"]);
+fluid.test.runTests(["fluid.tests.couchConfig.couchConfigTest", "fluid.tests.couchConfig.retryableCouchConfigSuccessTest", "fluid.tests.couchConfig.retryableCouchConfigFailureTest"]);

--- a/tests/js/couchConfigTests.js
+++ b/tests/js/couchConfigTests.js
@@ -74,9 +74,9 @@ fluid.defaults("fluid.tests.couchConfig.testCouchConfig", {
 });
 
 fluid.defaults("fluid.tests.couchConfig.testCouchConfigRetryable", {
-    gradeNames: ["fluid.couchConfig.pipeline.retryable", "fluid.tests.couchConfig.testCouchConfig"],
+    gradeNames: ["fluid.couchConfig.pipeline.retrying", "fluid.tests.couchConfig.testCouchConfig"],
     components: {
-        retrying: {
+        retryingBehaviour: {
             options: {
                 retryOptions: {
                     maxRetries: 3,

--- a/tests/js/couchConfigTests.js
+++ b/tests/js/couchConfigTests.js
@@ -86,7 +86,7 @@ fluid.defaults("fluid.tests.couchConfig.couchConfigTester", {
                 "resolveArgs": ["Database documents were created/updated successfully"]
             },
             {
-                "func": "fluid.tests.couchConfig.testDbDocument",
+                "func": "fluid.tests.couchConfig.verifyDbDocument",
                 args: ["{couchConfigTest}.couchConfig.options.couchOptions.dbName",
                     "{couchConfigTest}.couchConfig.options.couchOptions.couchUrl",
                     "{couchConfigTest}.couchConfig.options.dbDocuments.testDoc",
@@ -112,7 +112,7 @@ fluid.defaults("fluid.tests.couchConfig.couchConfigTester", {
                 "resolveArgs": ["Database design document were created/updated successfully"]
             },
             {
-                "func": "fluid.tests.couchConfig.testDbView",
+                "func": "fluid.tests.couchConfig.verifyDbView",
                 args: ["{couchConfigTest}.couchConfig.options.couchOptions.dbName",
                     "{couchConfigTest}.couchConfig.options.couchOptions.couchUrl",
                     "{couchConfigTest}.couchConfig.options.dbDesignDocuments",
@@ -148,7 +148,7 @@ fluid.tests.couchConfig.testReduceFunction = function (keys, values, rereduce) {
     return sum(values);
 };
 
-fluid.tests.couchConfig.testDbDocument = function (dbName, couchUrl, expectedTestDoc, completionEvent) {
+fluid.tests.couchConfig.verifyDbDocument = function (dbName, couchUrl, expectedTestDoc, completionEvent) {
     var nano = require("nano")(couchUrl);
     var db = nano.use(dbName);
 
@@ -162,7 +162,7 @@ fluid.tests.couchConfig.testDbDocument = function (dbName, couchUrl, expectedTes
     });
 };
 
-fluid.tests.couchConfig.testDbView = function (dbName, couchUrl, expectedView, completionEvent) {
+fluid.tests.couchConfig.verifyDbView = function (dbName, couchUrl, expectedView, completionEvent) {
     var nano = require("nano")(couchUrl);
     var db = nano.use(dbName);
 

--- a/tests/js/couchConfigTests.js
+++ b/tests/js/couchConfigTests.js
@@ -168,7 +168,6 @@ fluid.tests.couchConfig.testDbView = function (dbName, couchUrl, expectedView, c
 
     db.get("_design/testViews", function (err, actualDesignDoc) {
         if (!err) {
-            console.log(actualDesignDoc);
             fluid.tests.couchConfig.compareFunctions("The actual view map function is the same as expected", expectedView.testViews.test.map, actualDesignDoc.test.map);
             fluid.tests.couchConfig.compareFunctions("The actual view reduce function is the same as expected", expectedView.testViews.test.reduce, actualDesignDoc.test.reduce);
             fluid.tests.couchConfig.compareFunctions("The actual validate function is the same as expected", expectedView.testViews.validate_doc_update, actualDesignDoc.validate_doc_update);


### PR DESCRIPTION
This adds a generic `retryingBehaviour` grade that can be used by other grades to implement basic retrying behaviour in the nature of "wait 10 seconds between attempts, try 3 times before giving up".

`fluid.couchConfig.pipeline.retryingBehaviour` and `fluid.couchConfig.pipeline.retrying` use this functionality to create a version of `fluid.couchConfig.pipeline` that will try a number of times to run a configuration before giving up. This is most useful in distributed environments (such as bringing up a multi-container application) where CouchDB being immediately available can't be guaranteed.